### PR TITLE
FIx recursion not turning off

### DIFF
--- a/src/main/java/com/joshepen/everything/ui/UI.java
+++ b/src/main/java/com/joshepen/everything/ui/UI.java
@@ -186,7 +186,7 @@ public class UI extends javax.swing.JFrame implements iUI {
     }//GEN-LAST:event_chooseDirButtonActionPerformed
 
     private void recursiveCheckBoxActionPerformed(java.awt.event.ActionEvent evt) {//GEN-FIRST:event_recursiveCheckBoxActionPerformed
-        directoryHandler.setRecursive(recursiveCheckBox.isEnabled());
+        directoryHandler.setRecursive(recursiveCheckBox.isSelected());
     }//GEN-LAST:event_recursiveCheckBoxActionPerformed
 
     private void caseSensitiveCheckBoxActionPerformed(java.awt.event.ActionEvent evt) {//GEN-FIRST:event_caseSensitiveCheckBoxActionPerformed


### PR DESCRIPTION
Closes #23.
isSelected and isEnabled are apparently different things. Good to know I guess. isEnabled was activating the action listener before the box actually unchecked, and for whatever reason isSelected doesn't do that.